### PR TITLE
FEATURE: Allow to configure formatters

### DIFF
--- a/Classes/LoggerFactory.php
+++ b/Classes/LoggerFactory.php
@@ -132,7 +132,7 @@ class LoggerFactory implements PsrLoggerFactoryInterface
 
             $formatterClass = $handlerConfiguration['formatterClassName'] ?? false;
             if ($formatterClass) {
-                if (!class_exists($handlerClass)) {
+                if (!class_exists($formatterClass)) {
                     throw new InvalidConfigurationException(sprintf('The given formatter class "%s" does not exist, please check configuration for handler "%s".', $formatterClass, $identifier), 1702638212);
                 }
                 if (!$handler instanceof FormattableHandlerInterface) {

--- a/README.md
+++ b/README.md
@@ -78,3 +78,29 @@ afterwards.
 
 For more information about handlers and their configuration check also the monolog [documentation on handlers, formatters & processors](https://seldaek.github.io/monolog/doc/02-handlers-formatters-processors.html).
  
+## Formatters
+
+To add a formatter to a handler, configure it like this:
+
+```yaml
+Neos:
+  Flow:
+    log:
+      psr3:
+        'Flowpack\Monolog\LoggerFactory':
+          '<name of the logger>':
+            handler:
+              '<identifier for this handler>':
+                className: '<monolog compatible handler class name fully qualified>'
+                arguments:
+                  0: '<the first argument given to the constructor of the handler>'
+                # any formatter compatible with monolog
+                formatterClassName: '<monolog compatible formatter class name fully qualified>'
+                # optional arguments for the formatter
+                formatterArguments:
+                  0: '<the first argument given to the constructor of the formatter>'
+```
+
+For this to work the used handler must implement monolog's `FormattableHandlerInterface`.
+
+For more information about formatters and their configuration check also the monolog [documentation on handlers, formatters & processors](https://seldaek.github.io/monolog/doc/02-handlers-formatters-processors.html).

--- a/README.md
+++ b/README.md
@@ -1,39 +1,36 @@
-Monolog Integration for Flow
-============================
+# Monolog Integration for Flow
 
 Provides a [monolog](https://github.com/Seldaek/monolog) factory to be used with Flow.
 
-❗ 
+❗
 > This package replaces all Neos Flow logs (Security, System, Query, I18n) with Monolog by default.
 > To change that and the handlers check the Settings.yaml. See also configuration notes below.
 
- 👻
-
+👻
 > The monolog format is slightly different than the default Flow log file format, 
 > also the configured monolog handler does **no log rotation** like the Flow log does, 
 > so you need to take care of that.
 
 
-Installation
-------------
+## Installation
+
 Use composer to install this package:
 
 `composer require flowpack/monolog`
 
 All Framework logs should now be in monolog format and you need to add configuration for any other logs you might want.
 
-Configuration
--------------
+## Configuration
 
 You have several ways to configure monolog with this package, the easiest is seen in the configuration for the Neos Flow logs in this package:
 
-```
+```yaml
 Neos:
   Flow:
     log:
       psr3:
         'Flowpack\Monolog\LoggerFactory':
-          # name of the logger as flow addresses it, eg. "systemLogger"
+          # name of the logger as Flow addresses it, eg. "systemLogger"
           '<name of the logger>':
             handler:
               # unique name for this handler in this log, for extending the configuration
@@ -41,15 +38,15 @@ Neos:
                 className: '<monolog compatible handler class name fully qualified>'
                 # sorting for this handler if you want it deterministic with overwrites
                 position: 100
-                # arguments given to the handler, zero index based, as the hander constructor expects them
+                # arguments given to the handler, zero index based, as the handler constructor expects them
                 arguments:
                   0: '<the first argument given to the constructor of the handler>'
               # another handler could follow here
 ```
 
-Another option is to create preset handlers, eg. if you need to use the same handler with the same configuration in multiple places, no overrides of this default configuration is possible at this time:
+Another option is to create preset handlers, e.g. if you need to use the same handler with the same configuration in multiple places, no overrides of this default configuration is possible at this time:
 
-```
+```yaml
 Flowpack:
   Monolog:
     handler:
@@ -57,7 +54,7 @@ Flowpack:
       '<presetName>':
         className: '<monolog compatible handler class name fully qualified>'
         # note that preset handlers currently cannot have a position, they are sorted as configured
-        # arguments given to the handler, zero index based, as the hander constructor expects them
+        # arguments given to the handler, zero index based, as the handler constructor expects them
         arguments:
             0: '<the first argument given to the constructor of the handler>'
 
@@ -66,16 +63,18 @@ Neos:
     log:
       psr3:
         'Flowpack\Monolog\LoggerFactory':
-          # name of the logger as flow addresses it, eg. "systemLogger"
+          # name of the logger as Flow addresses it
           '<name of the logger>':
             handler:
               # the presetName should be the same as in above preset configuration
               '<identifier for this handler>': '<presetName>'
 ```
 
+⚠️ Note that using presets does not work for loggers needed early in the bootstrap, as the settings
+for the Flowpack.Monolog package itself are injected rather late and the preset is only available
+afterwards.
 
-Handlers
---------
+## Handlers
 
-For more information about handlers and their configuration check also the [monolog](https://github.com/Seldaek/monolog) package.
+For more information about handlers and their configuration check also the monolog [documentation on handlers, formatters & processors](https://seldaek.github.io/monolog/doc/02-handlers-formatters-processors.html).
  

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,9 @@
     "type": "neos-package",
     "description": "Monolog integration for Flow",
     "require": {
-        "neos/flow": "^5.0 || ^6.0 || ^7.0 || dev-master",
-        "monolog/monolog": "^1.23 || ^2.3"
+        "ext-json": "*",
+        "neos/flow": "^7.3 || ^8.0",
+        "monolog/monolog": "^2.3 || ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
To add a formatter to a handler, configure it like this:

```yaml
Neos:
  Flow:
    log:
      psr3:
        'Flowpack\Monolog\LoggerFactory':
          '<name of the logger>':
            handler:
              '<identifier for this handler>':
                className: '<monolog compatible handler class name fully qualified>'
                arguments:
                  0: '<the first argument given to the constructor of the handler>'
                # any formatter compatible with monolog
                formatterClassName: '<monolog compatible formatter class name fully qualified>'
                # optional arguments for the formatter
                formatterArguments:
                  0: '<the first argument given to the constructor of the formatter>'
```

For this to work the used handler must implement monolog's `FormattableHandlerInterface`.
